### PR TITLE
Graceful api server shutdown tweaks

### DIFF
--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -3,11 +3,11 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/redis/go-redis/v9"
 	"math"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"

--- a/cmd/argocd-server/commands/argocd_server.go
+++ b/cmd/argocd-server/commands/argocd_server.go
@@ -3,11 +3,11 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/redis/go-redis/v9"
 	"math"
 	"time"
 
 	"github.com/argoproj/pkg/stats"
-	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -209,6 +209,8 @@ func NewCommand() *cobra.Command {
 				if closer != nil {
 					closer()
 				}
+				log.Info("API Server successfully shut down.")
+				break
 			}
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -585,15 +585,17 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 			}
 		}()
 
-		// Shutdown https server
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := httpsS.Shutdown(sCtx)
-			if err != nil {
-				log.Errorf("Error shutting down https server: %s", err)
-			}
-		}()
+		if httpsS != nil {
+			// Shutdown https server
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := httpsS.Shutdown(sCtx)
+				if err != nil {
+					log.Errorf("Error shutting down https server: %s", err)
+				}
+			}()
+		}
 
 		// Shutdown gRPC server
 		wg.Add(1)
@@ -612,12 +614,14 @@ func (a *ArgoCDServer) Run(ctx context.Context, listeners *Listeners) {
 			}
 		}()
 
-		// Shutdown tls server
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			tlsm.Close()
-		}()
+		if tlsm != nil {
+			// Shutdown tls server
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				tlsm.Close()
+			}()
+		}
 
 		// Shutdown tcp server
 		wg.Add(1)


### PR DESCRIPTION
Looks like the for loop in argocd_server tries to start the server back up immediately after it gracefully shuts down. So I think the break makes sense.

I assume it was originally designed to gracefully handle crashes. But imo that's Kubernetes' job.